### PR TITLE
Fix regex for parsing server_url when connecting

### DIFF
--- a/lib/salesforce_bulk/connection.rb
+++ b/lib/salesforce_bulk/connection.rb
@@ -82,7 +82,7 @@ module SalesforceBulk
     end
 
     def parse_instance()
-      @server_url =~ /https:\/\/([a-z]{2,2}[0-9]{1,2})-api/
+      @server_url =~ /https:\/\/([a-z]{2,2}\d{1,2})/
       @instance = $~.captures[0]
     end
 


### PR DESCRIPTION
The server_url doesn't always include '-api', which causes $~.captures[0] to throw a NoMethodError. Sadness! Tightening up the regex solved this completely. 
