### PR TITLE
Check response content type

### DIFF
--- a/lib/salesforce_bulk/client.rb
+++ b/lib/salesforce_bulk/client.rb
@@ -142,7 +142,7 @@ module SalesforceBulk
     def batch_result(jobId, batchId)
       response = http_get("job/#{jobId}/batch/#{batchId}/result")
 
-      if response.body =~ /<.*?>/m
+      if ['application/xml', 'text/xml'].include? response.content_type
         result = XmlSimple.xml_in(response.body)
 
         if result['result'].present?

--- a/test/fixtures/batch_result_list_failed_response.csv
+++ b/test/fixtures/batch_result_list_failed_response.csv
@@ -1,0 +1,3 @@
+"Id","Success","Created","Error"
+"a00E0000002V30LIAS","false","false","Error message"
+"a00E0000002V30MIAS","false","false","Error message with <b>HTML</b>"


### PR DESCRIPTION
The _salesforce_bulk_ gem handles all Salesforce responses that contain XML tags as XML. This brings some issues when the error message from Salesforce is in CSV format and contains HTML tags

Checking the content type of the Salesforce catches the cases when it has valid response with error messages that include HTML.
Add a test that checks if the response that is not XML and has HTML in it is parsed as CSV.
/cc @halacheva @hdokov