### PR TITLE
Add support for Rails 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,15 @@ gemfile:
   - gemfiles/rails4.0.gemfile
   - gemfiles/rails4.1.gemfile
   - gemfiles/rails4.2.gemfile
+  - gemfiles/rails5.0.gemfile
 matrix:
   exclude:
     - gemfile: gemfiles/rails3.2.gemfile
       rvm: 2.2.2
+    - gemfile: gemfiles/rails5.0.gemfile
+      rvm: 2.0.0
+    - gemfile: gemfiles/rails5.0.gemfile
+      rvm: 2.1.6
 notifications:
   email:
     on_success: always

--- a/gemfiles/rails5.0.gemfile
+++ b/gemfiles/rails5.0.gemfile
@@ -1,0 +1,4 @@
+source "http://rubygems.org"
+gemspec :path => '../'
+
+gem 'activesupport', '~> 5.0.1'

--- a/salesforcebulk.gemspec
+++ b/salesforcebulk.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
 
   s.files         = `git ls-files lib README.md`.split("\n")
 
-  s.add_dependency "activesupport", '>= 3.2.0', '< 5.0'
+  s.add_dependency "activesupport", '>= 3.2.0', '< 6'
   s.add_dependency "xml-simple"
 
   s.add_development_dependency "rake"


### PR DESCRIPTION
This simply relaxes the upper bound on the `activesupport` version, no code changes required.

Ruby 2.2.2+ is required by Rails 5 (c.f. http://edgeguides.rubyonrails.org/5_0_release_notes.html ), so the combinations with older versions are excluded from the build matrix.