### PR TITLE
Use the right tag name for total batches in job info

### DIFF
--- a/lib/salesforce_bulk/job.rb
+++ b/lib/salesforce_bulk/job.rb
@@ -40,7 +40,7 @@ module SalesforceBulk
       job.in_progress_batches = data['numberBatchesInProgress'].to_i
       job.completed_batches = data['numberBatchesCompleted'].to_i
       job.failed_batches = data['numberBatchesFailed'].to_i
-      job.total_batches = data['totalBatches'].to_i
+      job.total_batches = data['numberBatchesTotal'].to_i
       job.retries = data['retries'].to_i
       job.processed_records = data['numberRecordsProcessed'].to_i
       job.failed_records = data['numberRecordsFailed'].to_i


### PR DESCRIPTION
As documented in https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/asynch_api_jobs_get_details.htm