### PR TITLE
Added support for re-authenticating

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,23 +3,15 @@ script: "bundle exec rake test"
 cache: bundler
 sudo: false
 rvm:
-  - 2.0.0
-  - 2.1.6
-  - 2.2.2
+  - 2.3
+  - 2.4
+  - 2.5
+  - 2.6
 gemfile:
-  - gemfiles/rails3.2.gemfile
   - gemfiles/rails4.0.gemfile
   - gemfiles/rails4.1.gemfile
   - gemfiles/rails4.2.gemfile
   - gemfiles/rails5.0.gemfile
-matrix:
-  exclude:
-    - gemfile: gemfiles/rails3.2.gemfile
-      rvm: 2.2.2
-    - gemfile: gemfiles/rails5.0.gemfile
-      rvm: 2.0.0
-    - gemfile: gemfiles/rails5.0.gemfile
-      rvm: 2.1.6
 notifications:
   email:
     on_success: always

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ rvm:
   - 2.5
   - 2.6
 gemfile:
-  - gemfiles/rails4.0.gemfile
   - gemfiles/rails4.1.gemfile
   - gemfiles/rails4.2.gemfile
   - gemfiles/rails5.0.gemfile

--- a/gemfiles/rails3.2.gemfile
+++ b/gemfiles/rails3.2.gemfile
@@ -1,5 +1,0 @@
-source "http://rubygems.org"
-gemspec :path => '../'
-
-gem 'activesupport', '~> 3.2'
-gem 'minitest', '~> 4.3'

--- a/gemfiles/rails4.0.gemfile
+++ b/gemfiles/rails4.0.gemfile
@@ -1,5 +1,0 @@
-source "http://rubygems.org"
-gemspec :path => '../'
-
-gem 'activesupport', '~> 4.0.13'
-gem 'minitest', '~> 4.3'

--- a/lib/salesforce_bulk/client.rb
+++ b/lib/salesforce_bulk/client.rb
@@ -17,6 +17,9 @@ module SalesforceBulk
     # The API version the client is using. Defaults to 24.0.
     attr_accessor :version
 
+    # The ID for authenticated session
+    attr_reader :session_id
+
     def initialize(options={})
       if options.is_a?(String)
         options = YAML.load_file(options)
@@ -38,6 +41,10 @@ module SalesforceBulk
     end
 
     def authenticate
+      # Clear session attributes just in case client already had a session
+      @session_id = nil
+      self.instance_host = nil
+
       xml = '<?xml version="1.0" encoding="utf-8"?>'
       xml += '<env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"'
       xml += ' xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"'

--- a/salesforcebulk.gemspec
+++ b/salesforcebulk.gemspec
@@ -20,8 +20,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rake"
   s.add_development_dependency "rdoc"
   s.add_development_dependency "mocha", '~> 0.13.0'
-  s.add_development_dependency "shoulda", '~> 3.5.0'
-  s.add_development_dependency "webmock", '~> 1.8.11'
+  s.add_development_dependency "shoulda", '~> 3.5'
+  s.add_development_dependency "webmock", '~> 3.0'
   s.add_development_dependency 'minitest'
   s.add_development_dependency 'bump'
   s.add_development_dependency 'wwtd'

--- a/salesforcebulk.gemspec
+++ b/salesforcebulk.gemspec
@@ -12,7 +12,9 @@ Gem::Specification.new do |s|
 
   s.files         = `git ls-files lib README.md`.split("\n")
 
-  s.add_dependency "activesupport", '>= 3.2.0', '< 6'
+  s.required_ruby_version = '>= 2.3'
+
+  s.add_dependency "activesupport", '>= 4', '< 6'
   s.add_dependency "xml-simple"
 
   s.add_development_dependency "rake"

--- a/test/lib/test_initialization.rb
+++ b/test/lib/test_initialization.rb
@@ -57,10 +57,27 @@ class TestInitialization < ActiveSupport::TestCase
     assert_requested :post, "https://#{@client.login_host}/services/Soap/u/24.0", :body => request, :headers => headers, :times => 1
     
     assert_equal @client.instance_host, 'na9-api.salesforce.com'
-    assert_equal @client.instance_variable_get('@session_id'), '00DE0000000YSKp!AQ4AQNQhDKLMORZx2NwZppuKfure.ChCmdI3S35PPxpNA5MHb3ZVxhYd5STM3euVJTI5.39s.jOBT.3mKdZ3BWFDdIrddS8O'
+    assert_equal @client.session_id, '00DE0000000YSKp!AQ4AQNQhDKLMORZx2NwZppuKfure.ChCmdI3S35PPxpNA5MHb3ZVxhYd5STM3euVJTI5.39s.jOBT.3mKdZ3BWFDdIrddS8O'
     assert_equal @client, result
   end
-  
+
+  test "re-authenticate" do
+    headers = {'Content-Type' => 'text/xml', 'SOAPAction' => 'login'}
+    request = fixture("login_request.xml")
+    response = fixture("login_response.xml")
+
+    assert_requested :post, "https://#{@client.login_host}/services/Soap/u/24.0", :body => request, :headers => headers, :times => 2
+    stub_request(:post, "https://#{@client.login_host}/services/Soap/u/24.0").with(:body => request, :headers => headers).to_return(:body => response, :status => 200)
+
+    result = @client.authenticate()
+
+    assert_equal @client.instance_host, 'na9-api.salesforce.com'
+    assert_equal @client.session_id, '00DE0000000YSKp!AQ4AQNQhDKLMORZx2NwZppuKfure.ChCmdI3S35PPxpNA5MHb3ZVxhYd5STM3euVJTI5.39s.jOBT.3mKdZ3BWFDdIrddS8O'
+    assert_equal @client, result
+
+    result = @client.authenticate()
+  end
+
   test "parsing instance id from server url" do
     assert_equal @client.instance_id('https://na1-api.salesforce.com'), 'na1-api'
     assert_equal @client.instance_id('https://na23-api.salesforce.com'), 'na23-api'


### PR DESCRIPTION
Calling `authenticate` multiple times should not error, otherwise it's not possible to create a new session for same client if previous one expires.