### PR TITLE
Add support for Rails 6.0 and 6.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,18 @@ gemfile:
   - gemfiles/rails5.0.gemfile
   - gemfiles/rails5.1.gemfile
   - gemfiles/rails5.2.gemfile
+  - gemfiles/rails6.0.gemfile
+  - gemfiles/rails6.1.gemfile
+matrix:
+  exclude:
+    - rvm: 2.3
+      gemfile: gemfiles/rails6.0.gemfile
+    - rvm: 2.4
+      gemfile: gemfiles/rails6.0.gemfile
+    - rvm: 2.3
+      gemfile: gemfiles/rails6.1.gemfile
+    - rvm: 2.4
+      gemfile: gemfiles/rails6.1.gemfile
 notifications:
   email:
     on_success: always

--- a/gemfiles/rails6.0.gemfile
+++ b/gemfiles/rails6.0.gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+gemspec path: '../'
+
+gem 'activesupport', '~> 6.0.0'

--- a/gemfiles/rails6.1.gemfile
+++ b/gemfiles/rails6.1.gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+gemspec path: '../'
+
+gem 'activesupport', '~> 6.1.0'

--- a/salesforcebulk.gemspec
+++ b/salesforcebulk.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.3'
 
-  s.add_dependency "activesupport", '>= 4', '< 6'
+  s.add_dependency "activesupport", '>= 4', '< 6.2'
   s.add_dependency "xml-simple"
 
   s.add_development_dependency "rake"


### PR DESCRIPTION
This change adds support for Rails 6.0 and 6.1 by increasing the upper bound of the `activesupport` dependency to `< 6.2`.

To ensure tests pass using Rails 6.0 and 6.1, the Travis CI matrix has been updated with `rails6.0.gemfile` and `rails6.1.gemfile`.

**Note:** Rails 6.x [requires](https://edgeguides.rubyonrails.org/upgrading_ruby_on_rails.html#ruby-versions) `Ruby 2.5.0` or newer, so exclusions to the matrix have been specified for  `rails6.0.gemfile` and `rails6.1.gemfile`.