### PR TITLE
Avoid NoMethodError exceptions on nil when authentication response is a redirect

### DIFF
--- a/lib/salesforce_bulk/salesforce_error.rb
+++ b/lib/salesforce_bulk/salesforce_error.rb
@@ -10,7 +10,7 @@ module SalesforceBulk
       self.response = response
       self.error_code = response.code
 
-      if error_code =~ /3\d\d/
+      if (300..308).cover?(error_code.to_i)
         message = "Moved to #{response.header['location']}"
       else
         data = XmlSimple.xml_in(response.body, 'ForceArray' => false)


### PR DESCRIPTION
When the `authenticate` HTTP response is a redirect (e.g.: 307), it's not correctly processed, causing an error that occludes the issue for library users. This PR adds handling for those cases, including the new location in the error message and storing the response's status code.